### PR TITLE
Make sure VM Maestro recognizes this repository as a "Project."

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>INE-VIRL</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>com.cisco.vmmaestro.validation.topologyBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>com.cisco.vmmaestro.validation.topologyNature</nature>
+	</natures>
+</projectDescription>


### PR DESCRIPTION
For VM Maestro to recognize the INE-VIRL repository as a topology
project automatically (during the initial Git clone, for example), we need 
a .project file.  Note that the .project file can live in the root of the
repository or in the workbook sub-folder, depending on whether INE wants
users to see multiple projects in VM Maestro or just one project with
multiple sub-folders.
