### PR TITLE
Removing configs with illegal characters from .virl topologies

### DIFF
--- a/CCIE.RSv5.Workbook/advanced.technology.labs/dhcp.advanced.initial.virl
+++ b/CCIE.RSv5.Workbook/advanced.technology.labs/dhcp.advanced.initial.virl
@@ -85,31 +85,31 @@ end
 </entry></extensions>
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
     <node name="SW1" type="SIMPLE" subtype="IOSvL2" location="346,347">

--- a/CCIE.RSv5.Workbook/advanced.technology.labs/dhcp.information.option.initial.virl
+++ b/CCIE.RSv5.Workbook/advanced.technology.labs/dhcp.information.option.initial.virl
@@ -85,31 +85,31 @@ end
 </entry></extensions>
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
     <node name="SW1" type="SIMPLE" subtype="IOSvL2" location="346,347">

--- a/CCIE.RSv5.Workbook/advanced.technology.labs/dhcp.ppp.initial.virl
+++ b/CCIE.RSv5.Workbook/advanced.technology.labs/dhcp.ppp.initial.virl
@@ -93,31 +93,31 @@ end
 </entry></extensions>
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
     <node name="SW1" type="SIMPLE" subtype="IOSvL2" location="346,347">

--- a/CCIE.RSv5.Workbook/advanced.technology.labs/eigrpv6.basic.virl
+++ b/CCIE.RSv5.Workbook/advanced.technology.labs/eigrpv6.basic.virl
@@ -85,31 +85,31 @@ end
 </entry></extensions>
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
     <node name="SW1" type="SIMPLE" subtype="IOSvL2" location="346,347">

--- a/CCIE.RSv5.Workbook/advanced.technology.labs/eigrpv6.initial.virl
+++ b/CCIE.RSv5.Workbook/advanced.technology.labs/eigrpv6.initial.virl
@@ -83,31 +83,31 @@ end
 </entry></extensions>
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
     <node name="SW1" type="SIMPLE" subtype="IOSvL2" location="346,347">

--- a/CCIE.RSv5.Workbook/advanced.technology.labs/ipv6.global.initial.virl
+++ b/CCIE.RSv5.Workbook/advanced.technology.labs/ipv6.global.initial.virl
@@ -86,31 +86,31 @@ end
 </entry></extensions>
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
     <node name="SW1" type="SIMPLE" subtype="IOSvL2" location="346,347">

--- a/CCIE.RSv5.Workbook/advanced.technology.labs/ipv6.initial.virl
+++ b/CCIE.RSv5.Workbook/advanced.technology.labs/ipv6.initial.virl
@@ -92,31 +92,31 @@ end
 </entry></extensions>
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
     <node name="SW1" type="SIMPLE" subtype="IOSvL2" location="346,347">

--- a/CCIE.RSv5.Workbook/advanced.technology.labs/ipv6.multicast.initial.virl
+++ b/CCIE.RSv5.Workbook/advanced.technology.labs/ipv6.multicast.initial.virl
@@ -89,31 +89,31 @@ end
 </entry></extensions>
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
     <node name="SW1" type="SIMPLE" subtype="IOSvL2" location="346,347">

--- a/CCIE.RSv5.Workbook/advanced.technology.labs/ipv6.nbma.initial.virl
+++ b/CCIE.RSv5.Workbook/advanced.technology.labs/ipv6.nbma.initial.virl
@@ -95,31 +95,31 @@ end
 </entry></extensions>
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
     <node name="SW1" type="SIMPLE" subtype="IOSvL2" location="346,347">

--- a/CCIE.RSv5.Workbook/advanced.technology.labs/ipv6.redistribution.initial.virl
+++ b/CCIE.RSv5.Workbook/advanced.technology.labs/ipv6.redistribution.initial.virl
@@ -88,31 +88,31 @@ end
 </entry></extensions>
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
     <node name="SW1" type="SIMPLE" subtype="IOSvL2" location="346,347">

--- a/CCIE.RSv5.Workbook/advanced.technology.labs/object.tracking.initial.virl
+++ b/CCIE.RSv5.Workbook/advanced.technology.labs/object.tracking.initial.virl
@@ -85,31 +85,31 @@ end
 </entry></extensions>
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
     <node name="SW1" type="SIMPLE" subtype="IOSvL2" location="346,347">

--- a/CCIE.RSv5.Workbook/advanced.technology.labs/ospfv3.basic.virl
+++ b/CCIE.RSv5.Workbook/advanced.technology.labs/ospfv3.basic.virl
@@ -88,31 +88,31 @@ end
 </entry></extensions>
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
     <node name="SW1" type="SIMPLE" subtype="IOSvL2" location="346,347">

--- a/CCIE.RSv5.Workbook/advanced.technology.labs/ospfv3.initial.virl
+++ b/CCIE.RSv5.Workbook/advanced.technology.labs/ospfv3.initial.virl
@@ -83,31 +83,31 @@ end
 </entry></extensions>
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
     <node name="SW1" type="SIMPLE" subtype="IOSvL2" location="346,347">

--- a/CCIE.RSv5.Workbook/advanced.technology.labs/ripng.initial.virl
+++ b/CCIE.RSv5.Workbook/advanced.technology.labs/ripng.initial.virl
@@ -87,31 +87,31 @@ end
 </entry></extensions>
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
     <node name="SW1" type="SIMPLE" subtype="IOSvL2" location="346,347">

--- a/CCIE.RSv5.Workbook/advanced.technology.labs/system.management.initial.virl
+++ b/CCIE.RSv5.Workbook/advanced.technology.labs/system.management.initial.virl
@@ -85,31 +85,31 @@ end
 </entry></extensions>
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R2" type="SIMPLE" subtype="IOSv" location="58,197">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R3" type="SIMPLE" subtype="IOSv" location="59,270">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R4" type="SIMPLE" subtype="IOSv" location="58,345">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R5" type="SIMPLE" subtype="IOSv" location="47,417">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R6" type="SIMPLE" subtype="IOSv" location="49,474">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R7" type="SIMPLE" subtype="IOSv" location="43,552">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R8" type="SIMPLE" subtype="IOSv" location="43,618">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R9" type="SIMPLE" subtype="IOSv" location="37,675">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
-    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741"><extensions><entry key="config" type="String">ÿþe</entry></extensions>
+    <node name="R10" type="SIMPLE" subtype="IOSv" location="32,741">
         <interface id="0" name="GigabitEthernet0/1"/>
     </node>
     <node name="SW1" type="SIMPLE" subtype="IOSvL2" location="346,347">


### PR DESCRIPTION
Bug fix: enable MV Maestro to open these files again.  We were getting
the error, "no data allowed in prolog," when attempting to open these
files.  The problem was that these topologies had  nodes with no config
but did have a config element in the XML.  That XML element contained
content that started with the 16-bit byte order mark (BOM).  The BOM
should only be used at the start of a Unicode file.  These illegal UTF-8
characters were tripping up the XML parser that we were using and
causing the strange error.

See also https://learningnetwork.cisco.com/thread/102734.